### PR TITLE
Fix filename generated on download

### DIFF
--- a/index.html
+++ b/index.html
@@ -490,6 +490,11 @@
       document.getElementById('progressBar').style.width = `${percent}%`;
     }
 
+    function formatDate(date) {
+      const pad = n => n.toString().padStart(2, '0');
+      return `${pad(date.getDate())}-${pad(date.getMonth() + 1)}-${date.getFullYear()}`;
+    }
+
     // Improved country detection - looks for country on the line before email
     async function getCountryFromEntry(entry) {
       const lines = entry.split('\n').map(line => line.trim()).filter(line => line.length > 0);
@@ -820,10 +825,11 @@
 
       let baseName = uploadedFileName || 'filtered_entries.txt';
       baseName = baseName.replace(/\.[^/.]+$/, '');
-      baseName = baseName.replace(/\s*\([^)]*\)\s*$/, '');
+      const firstWord = baseName.trim().split(/\s+/)[0];
 
-      const groupPart = currentGroupNames.length > 0 ? ' ' + currentGroupNames.join(' & ') : '';
-      a.download = `${baseName}${groupPart} (${currentFilteredEntries.length} Entries).txt`;
+      const groupPart = currentGroupNames.length > 0 ? currentGroupNames.join(' & ') : 'Filtered';
+      const dateStr = formatDate(new Date());
+      a.download = `${firstWord} - ${groupPart} (${currentFilteredEntries.length} Entries) - ${dateStr}.txt`;
 
       document.body.appendChild(a);
       a.click();


### PR DESCRIPTION
## Summary
- trim download filename to use first token from uploaded file
- show selected group names and filtered count
- append current date to the downloaded filename
- provide `formatDate` helper for consistent date formatting

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68899f18af988323b1a82ca40e81dd6b