### PR TITLE
Handle unknown countries in Other Countries group

### DIFF
--- a/index.html
+++ b/index.html
@@ -580,10 +580,15 @@
         
         for (const entry of chunk) {
           const entryCountry = await getCountryFromEntry(entry);
-          if (!entryCountry) continue;
-          
+          if (!entryCountry) {
+            if (groupName === 'H - Other Countries') {
+              count++;
+            }
+            continue;
+          }
+
           const standardizedEntryCountry = countryMap[entryCountry] || entryCountry;
-          
+
           for (const country of countries) {
             const standardizedCountry = countryMap[country] || country;
             if (standardizedEntryCountry.toLowerCase() === standardizedCountry.toLowerCase()) {
@@ -795,8 +800,10 @@
         
         await renderEntries(async (entry) => {
           const entryCountry = await getCountryFromEntry(entry);
-          if (!entryCountry) return false;
-          
+          if (!entryCountry) {
+            return filteredOptions.includes('H - Other Countries');
+          }
+
           const standardizedCountry = countryMap[entryCountry] || entryCountry;
           return selectedCountries.has(standardizedCountry.toLowerCase());
         }, filteredOptions);
@@ -889,8 +896,10 @@
       
       await renderEntries(async (entry) => {
         const entryCountry = await getCountryFromEntry(entry);
-        if (!entryCountry) return false;
-        
+        if (!entryCountry) {
+          return groupName === 'H - Other Countries';
+        }
+
         const standardizedCountry = countryMap[entryCountry] || entryCountry;
         return selectedCountries.has(standardizedCountry.toLowerCase());
       }, [groupName]);


### PR DESCRIPTION
## Summary
- Ensure group filtering includes entries lacking a country when 'H - Other Countries' is selected.
- Count entries without a recognized country toward "H - Other Countries" group totals.
- Support inclusion of countryless entries when a new group is created.

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891a7df20f48323ac39af1f4a06315a