### PR TITLE
Add group download buttons and batch download

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,6 +152,15 @@
     .btn-outline:hover {
       background-color: var(--light-gray);
     }
+
+    .btn-download {
+      background-color: #90ee90;
+      color: #000;
+    }
+
+    .btn-download:hover {
+      background-color: #76d275;
+    }
     
     .btn-group {
       display: flex;
@@ -264,6 +273,9 @@
       padding: 5px 10px;
       border-radius: 4px;
       font-size: 14px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
     }
     
     /* Loading indicator styles */
@@ -623,12 +635,92 @@
     function renderGroupCounts() {
       const container = document.getElementById('groupCounts');
       container.innerHTML = '';
-      
+      const allDiv = document.createElement('div');
+      allDiv.className = 'group-count-item';
+      const allBtn = document.createElement('button');
+      allBtn.className = 'btn btn-download';
+      allBtn.textContent = `Download All (${allParts.length})`;
+      allBtn.onclick = downloadAllGroups;
+      allDiv.appendChild(allBtn);
+      container.appendChild(allDiv);
+
       for (const groupName in groupCounts) {
         const div = document.createElement('div');
         div.className = 'group-count-item';
-        div.textContent = `${groupName}: ${groupCounts[groupName]}`;
+        const label = document.createElement('span');
+        label.textContent = groupName;
+        const btn = document.createElement('button');
+        btn.className = 'btn btn-download';
+        btn.textContent = `Download (${groupCounts[groupName]})`;
+        btn.onclick = () => downloadGroup(groupName);
+        div.appendChild(label);
+        div.appendChild(btn);
         container.appendChild(div);
+      }
+    }
+
+    async function getEntriesForGroup(groupName) {
+      if (!allParts.length || !countryGroups[groupName]) return [];
+
+      const entries = [];
+      const countries = countryGroups[groupName];
+      const chunkSize = 100;
+
+      for (let i = 0; i < allParts.length; i += chunkSize) {
+        const chunk = allParts.slice(i, i + chunkSize);
+
+        for (const entry of chunk) {
+          const entryCountry = await getCountryFromEntry(entry);
+          if (!entryCountry) {
+            if (groupName === 'H - Other Countries') {
+              entries.push(entry);
+            }
+            continue;
+          }
+
+          const standardizedEntryCountry = countryMap[entryCountry] || entryCountry;
+
+          for (const country of countries) {
+            const standardizedCountry = countryMap[country] || country;
+            if (standardizedEntryCountry.toLowerCase() === standardizedCountry.toLowerCase()) {
+              entries.push(entry);
+              break;
+            }
+          }
+        }
+      }
+
+      return entries;
+    }
+
+    async function downloadGroup(groupName) {
+      const entries = await getEntriesForGroup(groupName);
+      if (!entries.length) return;
+
+      const blob = new Blob([entries.join('\n\n')], { type: 'text/plain' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+
+      let baseName = uploadedFileName || 'filtered_entries.txt';
+      baseName = baseName.replace(/\.[^/.]+$/, '');
+      baseName = baseName.replace(/\(\s*\d+\s*entries?\s*\)/i, '').trim();
+
+      const hyphenIndex = baseName.indexOf(' - ');
+      const prefix = hyphenIndex !== -1 ? baseName.slice(0, hyphenIndex).trim() : baseName.trim();
+
+      const groupPart = getGroupPrefix(groupName);
+      a.download = `${prefix} - ${groupPart} - (${entries.length} Entries) CQ.txt`;
+
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    }
+
+    async function downloadAllGroups() {
+      for (const groupName in groupCounts) {
+        await downloadGroup(groupName);
       }
     }
 


### PR DESCRIPTION
## Summary
- Add light-green download buttons for each group with per-group entry counts
- Implement Download All feature to retrieve files for every group at once
- Append `CQ` suffix to generated filenames using existing naming logic

## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894a4aec31483239bd88f08dc6dbb9a