### PR TITLE
Reset file input after reading to allow reloading same file

### DIFF
--- a/index.html
+++ b/index.html
@@ -904,6 +904,8 @@
         document.getElementById('manualInput').value = entries;
         updateGroupCounts();
         renderEntries(() => true);
+        // Reset the file input so selecting the same file again triggers the change event
+        document.getElementById('fileInput').value = '';
       };
       reader.readAsText(file);
     });


### PR DESCRIPTION
## Summary
- Reset file input after processing to allow re-selecting the same file, ensuring entries reload automatically

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895a3384dcc8323a04f9f49cba002c1